### PR TITLE
Adding pubtools-pyxis-get-signatures [CLOUDDST-4422]

### DIFF
--- a/pubtools/_pyxis/pyxis_client.py
+++ b/pubtools/_pyxis/pyxis_client.py
@@ -53,3 +53,37 @@ class PyxisClient(object):
         resp.raise_for_status()
 
         return resp.json()["data"]
+
+    def get_container_signatures(self, manifest_digests, references, sig_key_ids):
+        """Get a list of signature metadata matching given fields.
+
+        Args:
+            manifest_digests (comma seperated str)
+                manifest_digest used for searching in signatures.
+            references (comma seperated str)
+                pull reference for image of signature stored.
+            sig_key_ids (comma seperated str)
+                signature id used to create signature
+
+        Returns:
+            list: List of signature metadata matching given fields.
+        """
+        signatures_url = "signatures"
+        filter_urls = []
+        if manifest_digests:
+            filter_urls.append("manifest_digest=in=({}),".format(manifest_digests))
+        if references:
+            filter_urls.append("reference=in=({}),".format(references))
+        if sig_key_ids:
+            filter_urls.append("sig_key_id=in=({}),".format(sig_key_ids))
+
+        if filter_urls:
+            signatures_url = "{}{}".format(signatures_url, "?filter=")
+            for filter_url in filter_urls:
+                signatures_url = "{}{}".format(signatures_url, filter_url)
+            signatures_url = signatures_url[0:-1]
+
+        resp = self.pyxis_session.get(signatures_url)
+        resp.raise_for_status()
+
+        return resp.json()["data"]

--- a/pubtools/_pyxis/pyxis_ops.py
+++ b/pubtools/_pyxis/pyxis_ops.py
@@ -54,6 +54,27 @@ GET_OPERATORS_INDICES_ARGS[("--organization",)] = {
 }
 
 
+GET_SIGNATURES_ARGS = CMD_ARGS.copy()
+GET_SIGNATURES_ARGS[("--manifest-digest",)] = {
+    "help": "comma separated manifest-digests to search",
+    "required": False,
+    "type": str,
+}
+
+
+GET_SIGNATURES_ARGS[("--reference",)] = {
+    "help": "reference",
+    "required": False,
+    "type": str,
+}
+
+GET_SIGNATURES_ARGS[("--sig-key-id",)] = {
+    "help": "sig-key-id",
+    "required": False,
+    "type": str,
+}
+
+
 def setup_pyxis_client(args, ccache_file):
     """
     Set up a PyxisClient instance according to specified parameters.
@@ -103,6 +124,29 @@ def get_operator_indices_main(sysargs=None):
         pyxis_client = setup_pyxis_client(args, tmpfile.name)
         res = pyxis_client.get_operator_indices(
             args.ocp_versions_range, args.organization
+        )
+
+        json.dump(res, sys.stdout, sort_keys=True, indent=4, separators=(",", ": "))
+        return res
+
+
+def get_signatures_main(sysargs=None):
+    """
+    Entrypoint for getting container signature metadata.
+
+    Returns:
+        list: container signature metadata satisfying the specified conditions.
+    """
+    parser = setup_arg_parser(GET_SIGNATURES_ARGS)
+    if sysargs:
+        args = parser.parse_args(sysargs[1:])
+    else:
+        args = parser.parse_args()  # pragma: no cover"
+
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        pyxis_client = setup_pyxis_client(args, tmpfile.name)
+        res = pyxis_client.get_container_signatures(
+            args.manifest_digest, args.reference, args.sig_key_id
         )
 
         json.dump(res, sys.stdout, sort_keys=True, indent=4, separators=(",", ": "))

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
     entry_points={
         "console_scripts": [
             "pubtools-pyxis-get-operator-indices = pubtools._pyxis.pyxis_ops:get_operator_indices_main",
+            "pubtools-pyxis-get-signatures = pubtools._pyxis.pyxis_ops:get_signatures_main"
         ]
     },
     include_package_data=True,

--- a/tests/test_pyxis_ops.py
+++ b/tests/test_pyxis_ops.py
@@ -247,3 +247,33 @@ def test_get_operator_indices(capsys):
 
     out, _ = capsys.readouterr()
     assert out == expected
+
+
+def test_get_signatures(capsys):
+    hostname = "https://pyxis.engineering.redhat.com/"
+    data = json.load(open("tests/test_data/sigs_with_reference.json"))[0:3]
+    manifest_digest = "sha256:998046100b4affa43df4348f3616cff3b05983a8e7397a53c40fab14"
+    args = [
+        "dummy",
+        "--pyxis-server",
+        hostname,
+        "--manifest-digest",
+        manifest_digest,
+        "--pyxis-ssl-crtfile",
+        "/root/name.crt",
+        "--pyxis-ssl-keyfile",
+        "/root/name.key",
+    ]
+
+    expected = json.dumps(data, sort_keys=True, indent=4, separators=(",", ": "))
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "{0}v1/signatures?filter=manifest_digest=in=({1})".format(
+                hostname, manifest_digest
+            ),
+            json={"data": data},
+        )
+        pyxis_ops.get_signatures_main(args)
+    out, _ = capsys.readouterr()
+    assert out == expected


### PR DESCRIPTION
pubtools-pyxis-get-signature entrypoint is added to
get container signature metadata from pyxis matching
the given paramaters like manifest_digest, reference,
sig_key_id